### PR TITLE
Initial modifications for deface.

### DIFF
--- a/app/views/admin/products/_additional_product_sub_menu.html.erb
+++ b/app/views/admin/products/_additional_product_sub_menu.html.erb
@@ -1,2 +1,2 @@
-<% # TODO: fix highlighting when selected %>
+<%# TODO: fix highlighting when selected %>
 <%= tab :product_customization_types, :match_path => '/product_customization_types' %>

--- a/app/views/orders/_cart_item_description.html.erb
+++ b/app/views/orders/_cart_item_description.html.erb
@@ -1,5 +1,1 @@
-<h4><%= link_to variant.product.name,  product_path(variant.product) %></h4>
-<%= variant_options variant %>
-<%= truncate(variant.product.description, :length => 100, :omission => "...") %>
-
 <%= render :partial => 'shared/additional_line_item_fields', :locals=>{:item => line_item} %>

--- a/app/views/products/_ad_hoc_option_types.html.erb
+++ b/app/views/products/_ad_hoc_option_types.html.erb
@@ -13,7 +13,7 @@
           <% class_str += ' required' if ahot.is_required %>
           <% class_str += ' ad_hoc' if !@product.ad_hoc_variant_exclusions.empty? %>
 
-          <% # render a custom partial based on the option type name? %>
+          <%# render a custom partial based on the option type name? %>
 
           <% partial_name = "products/ad_hoc_options/#{ot.name}" %>
           <% if lookup.exists?(partial_name,nil,true) %>

--- a/app/views/products/_content_for_head.html.erb
+++ b/app/views/products/_content_for_head.html.erb
@@ -14,7 +14,7 @@
       var exclusions = [
       <% @product.ad_hoc_variant_exclusions.each do |excl| %>
 	{
-	<% # account for every option type, even if empty %>
+	<%# account for every option type, even if empty %>
 	<% @product.ad_hoc_option_types.each do |ot| %>
 	  <% ov=excl.excluded_ad_hoc_option_values.detect { |eov| eov.ad_hoc_option_value.option_type == ot } %>
 
@@ -34,8 +34,8 @@
 
     <%= javascript_include_tag 'exclusions' %>
 
-  <% end # if exclusions %>
-<% end # content_for %>
+  <% end %> <%# if exclusions %>
+<% end %><%# content_for %>
 
 
 

--- a/app/views/products/_customizations.html.erb
+++ b/app/views/products/_customizations.html.erb
@@ -1,15 +1,15 @@
 <% if @product.product_customization_types %>
 
   <div id="product-customizations">
-    <% # this is a critical field (for ajax updates).  we use it to store pricing info returned from the server and later used by updatePrice() %>
+    <%# this is a critical field (for ajax updates).  we use it to store pricing info returned from the server and later used by updatePrice() %>
     <%= hidden_field_tag "customizations_price", 0 %>
 
-    <% # for finding optional partials %>
+    <%# for finding optional partials %>
     <% lookup=ActionView::LookupContext.new(ActionController::Base.view_paths, {:formats => [:html]}) %>
 
     <% @product.product_customization_types.each do |product_customization_type| %>
 
-      <% # render a custom partial based on the customization name? %>
+      <%# render a custom partial based on the customization name? %>
 
       <% partial_name = "products/customizations/#{product_customization_type.name}" %>
       <% if lookup.exists?(partial_name,nil,true) %>
@@ -28,7 +28,7 @@
 	          <% product_customization_type.customizable_product_options.each do |option| %>
               <li>
 	              <label><%= option.presentation %></label>
-                <% # field level partial exists? %>
+                <%# field level partial exists? %>
                 <% partial_name = "products/customizations/#{product_customization_type.name}/#{option.name}" %>
                 <% if lookup.exists?(partial_name,nil,true) %>
 	                <%= render :partial => partial_name, :locals=>{:customizable_product_option => option, :param_prefix => param_prefix} %>

--- a/app/views/products/_pricing.html.erb
+++ b/app/views/products/_pricing.html.erb
@@ -139,5 +139,5 @@
 <% end %>
 
 
-<% # end if Spree::Config[:use_ajax_pricing_updates] %>
+<%# end if Spree::Config[:use_ajax_pricing_updates] %>
 <% end %>

--- a/lib/spree_flexi_variants_hooks.rb
+++ b/lib/spree_flexi_variants_hooks.rb
@@ -1,13 +1,47 @@
 class SpreeFlexiVariantsHooks < Spree::ThemeSupport::HookListener
-  insert_after :admin_product_sub_tabs, 'admin/products/additional_product_sub_menu'
-  insert_after :admin_product_tabs, 'admin/products/additional_product_tabs'
-  insert_after :product_price, 'products/ad_hoc_option_types'
-  insert_after :product_price, 'products/customizations'
-
-  insert_after :product_price, 'products/pricing'
-  replace :order_details_line_item_row, 'shared/order_details_line_item_row'
-  replace :cart_item_description, 'orders/cart_item_description'
-  replace :admin_order_form_line_item_row, 'admin/orders/admin_order_form_line_item_row'
-
-  insert_before :cart_form, 'products/content_for_head'
+  Deface::Override.new(:virtual_path => "admin/shared/_product_sub_menu",
+                       :name => "converted_admin_product_sub_tabs_203014347",
+                       :insert_bottom => "[data-hook='admin_product_sub_tabs'], #admin_product_sub_tabs[data-hook]",
+                       :partial => "admin/products/additional_product_sub_menu",
+                       :disabled => false)
+  Deface::Override.new(:virtual_path => "admin/shared/_product_tabs",
+                       :name => "converted_admin_product_tabs_983418929",
+                       :insert_bottom => "[data-hook='admin_product_tabs'], #admin_product_tabs[data-hook]",
+                       :partial => "admin/products/additional_product_tabs",
+                       :disabled => false)
+  Deface::Override.new(:virtual_path => "products/_cart_form",
+                       :name => "converted_product_price_733808074",
+                       :insert_after => "[data-hook='product_price'], #product_price[data-hook]",
+                       :partial => "products/ad_hoc_option_types",
+                       :disabled => false)
+  Deface::Override.new(:virtual_path => "products/_cart_form",
+                       :name => "converted_product_price_290656527",
+                       :insert_after => "[data-hook='product_price'], #product_price[data-hook]",
+                       :partial => "products/customizations",
+                       :disabled => false)
+  Deface::Override.new(:virtual_path => "products/_cart_form",
+                       :name => "converted_product_price_331970321",
+                       :insert_after => "[data-hook='product_price'], #product_price[data-hook]",
+                       :partial => "products/pricing",
+                       :disabled => false)
+  Deface::Override.new(:virtual_path => "shared/_order_details",
+                       :name => "converted_order_details_line_item_row_27877400",
+                       :replace => "[data-hook='order_details_line_item_row'], #order_details_line_item_row[data-hook]",
+                       :partial => "shared/order_details_line_item_row",
+                       :disabled => false)
+  Deface::Override.new(:virtual_path => "orders/_line_item",
+                       :name => "converted_cart_item_description_722158932",
+                       :insert_bottom => "[data-hook='cart_item_description'], #cart_item_description[data-hook]",
+                       :partial => "orders/cart_item_description",
+                       :disabled => false)
+  Deface::Override.new(:virtual_path => "admin/orders/_line_item",
+                       :name => "converted_admin_order_form_line_item_row_459848395",
+                       :replace => "[data-hook='admin_order_form_line_item_row'], #admin_order_form_line_item_row[data-hook]",
+                       :partial => "admin/orders/admin_order_form_line_item_row",
+                       :disabled => false)
+  Deface::Override.new(:virtual_path => "products/show",
+                       :name => "converted_cart_form_594755007",
+                       :insert_before => "[data-hook='cart_form'], #cart_form[data-hook]",
+                       :partial => "products/content_for_head",
+                       :disabled => false)
 end


### PR DESCRIPTION
These are modifications necessary to make spree_flexi_variants work with the latest edge spree using the deface hooks.

NOTE:
There is still a problem with app/views/products/_pricing.html.erb. 
 All & signs are being converted to &amp; which is causing the javascript to break;  Obviously the output needs to go through 'raw' somewhere, but I haven't been able to make it work properly.

-Chris
