### PR TITLE
Settings fix

### DIFF
--- a/lib/spree_flexi_variants.rb
+++ b/lib/spree_flexi_variants.rb
@@ -15,7 +15,9 @@ module SpreeFlexiVariants
         preference :use_ajax_pricing_updates, :boolean, :default => true
       end
 
-      Spree::Config.set :use_ajax_pricing_updates => true
+      if Spree::Config.instance
+        Spree::Config.set :use_ajax_pricing_updates => true
+      end
 
       [Calculator::Engraving, Calculator::AmountTimesConstant, Calculator::ProductArea].each(&:register)
 


### PR DESCRIPTION
Prevents exception when running `rake db:migrate` if the database does not exist.
