### PR TITLE
Make Ad Hoc Option Values sortable

### DIFF
--- a/app/controllers/admin/ad_hoc_option_values_controller.rb
+++ b/app/controllers/admin/ad_hoc_option_values_controller.rb
@@ -1,0 +1,11 @@
+class Admin::AdHocOptionValuesController < Admin::ResourceController
+  def update_positions
+    params[:positions].each do |id, index|
+      AdHocOptionValue.update_all(['position=?', index], ['id=?', id])
+    end
+
+    respond_to do |format|
+      format.js  { render :text => 'Ok' }
+    end
+  end
+end

--- a/app/models/ad_hoc_option_value.rb
+++ b/app/models/ad_hoc_option_value.rb
@@ -4,6 +4,8 @@ class AdHocOptionValue < ActiveRecord::Base
   belongs_to :option_value
   # price_modifier
   alias :option_type :ad_hoc_option_type
+  acts_as_list :scope => :ad_hoc_option_type
+  default_scope order("position asc")
 
   def presentation
     option_value.presentation

--- a/app/views/admin/ad_hoc_option_types/_option_value_fields.html.erb
+++ b/app/views/admin/ad_hoc_option_types/_option_value_fields.html.erb
@@ -1,5 +1,5 @@
 <tr class="option_value fields" id="<%= dom_id(f.object) %>">
-  <td class='name'><span> <%= f.object.option_value.name %> </span></td>
+  <td class='name'><span class="handle"></span><span> <%= f.object.option_value.name %> </span></td>
   <td class='presentation'><span>  <%= f.object.option_value.presentation %> </span></td>
   <td class='price_modifier'><%= f.text_field :price_modifier %></td>
   <td class="actions"><%= link_to_remove_fields t("remove"), f %></td>

--- a/app/views/admin/ad_hoc_option_types/edit.html.erb
+++ b/app/views/admin/ad_hoc_option_types/edit.html.erb
@@ -6,7 +6,7 @@
   <legend><%= t("editing_option_type") %></legend>
   <%= render :partial => "form", :locals => { :f => f } %>
   <h3><%= t("option_values") %></h3>
-  <table class="index">
+  <table class="index sortable">
     <thead>
       <tr>
         <th><%= t("name") %></th>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,11 @@ Rails.application.routes.draw do
     resources :product_customization_types
 
     resources :ad_hoc_option_types do
+      resources :ad_hoc_option_values do
+        collection do
+          post :update_positions
+        end
+      end
       member do
         get :remove
       end

--- a/db/migrate/20111123031035_add_position_to_ad_hoc_option_values.rb
+++ b/db/migrate/20111123031035_add_position_to_ad_hoc_option_values.rb
@@ -1,0 +1,9 @@
+class AddPositionToAdHocOptionValues < ActiveRecord::Migration
+  def self.up
+    add_column :ad_hoc_option_values, :position, :integer
+  end
+
+  def self.down
+    remove_column :ad_hoc_option_values, :position
+  end
+end


### PR DESCRIPTION
I've added a position field to ad_hoc_option_values table and make the Ad Hoc Option Values sortable.

The AdHocOptionValue now has a default scope order by position in ascending order.
