### PR TITLE
Removed :disabled => false in overrrides

### DIFF
--- a/app/overrides/add_ad_hoc_option_types_to_cart_form.rb
+++ b/app/overrides/add_ad_hoc_option_types_to_cart_form.rb
@@ -1,5 +1,4 @@
 Deface::Override.new(:virtual_path => "spree/products/_cart_form",
                      :name => "converted_product_price_733808074",
                      :insert_after => "[data-hook='product_price'], #product_price[data-hook]",
-                     :partial => "spree/products/ad_hoc_option_types",
-                     :disabled => false)
+                     :partial => "spree/products/ad_hoc_option_types")

--- a/app/overrides/add_admin_tab_for_product_customization_types.rb
+++ b/app/overrides/add_admin_tab_for_product_customization_types.rb
@@ -1,5 +1,4 @@
 Deface::Override.new(:virtual_path => "spree/admin/shared/_product_sub_menu",
                      :name => "converted_admin_product_sub_tabs_203014347",
                      :insert_bottom => "[data-hook='admin_product_sub_tabs'], #admin_product_sub_tabs[data-hook]",
-                     :text => %{<%= tab :product_customization_types, :match_path => '/product_customization_types'},
-                     :disabled => false)
+                     :text => %{<%= tab :product_customization_types, :match_path => '/product_customization_types'})

--- a/app/overrides/add_cart_item_description.rb
+++ b/app/overrides/add_cart_item_description.rb
@@ -1,6 +1,4 @@
 Deface::Override.new(:virtual_path => "spree/orders/_line_item",
                          :name => "converted_cart_item_description_722158932",
                          :insert_bottom => "[data-hook='cart_item_description'], #cart_item_description[data-hook]",
-                         :partial => "spree/orders/cart_item_description",
-                         :disabled => false)
-
+                         :partial => "spree/orders/cart_item_description")

--- a/app/overrides/add_content_for_head_to_show_product.rb
+++ b/app/overrides/add_content_for_head_to_show_product.rb
@@ -1,5 +1,4 @@
     Deface::Override.new(:virtual_path => "spree/products/show",
                          :name => "converted_cart_form_594755007",
                          :insert_before => "[data-hook='cart_form'], #cart-form[data-hook]",
-                         :partial => "spree/products/content_for_head",
-                         :disabled => false)
+                         :partial => "spree/products/content_for_head")

--- a/app/overrides/add_customizations_to_cart_form.rb
+++ b/app/overrides/add_customizations_to_cart_form.rb
@@ -1,5 +1,4 @@
     Deface::Override.new(:virtual_path => "spree/products/_cart_form",
                          :name => "converted_product_price_290656527",
                          :insert_after => "[data-hook='product_price'], #product_price[data-hook]",
-                         :partial => "spree/products/customizations",
-                         :disabled => false)
+                         :partial => "spree/products/customizations")

--- a/app/overrides/add_extra_order_details_line_item_description.rb
+++ b/app/overrides/add_extra_order_details_line_item_description.rb
@@ -1,6 +1,5 @@
 Deface::Override.new(:virtual_path => "spree/shared/_order_details",
                      :name => "add_extra_order_details_line_item_description",
                      :insert_bottom => "[data-hook='order_item_description']",
-                     :partial => "spree/shared/extra_order_details_line_item_description",
-                     :disabled => false)
+                     :partial => "spree/shared/extra_order_details_line_item_description")
 

--- a/app/overrides/add_flexi_configuration_links_to_product_detail_menu.rb
+++ b/app/overrides/add_flexi_configuration_links_to_product_detail_menu.rb
@@ -1,6 +1,4 @@
 Deface::Override.new(:virtual_path => "spree/admin/shared/_product_tabs",
                      :name => "converted_admin_product_tabs_983418929",
                      :insert_bottom => "[data-hook='admin_product_tabs'], #admin_product_tabs[data-hook]",
-                     :partial => "spree/admin/products/additional_product_tabs",
-                     :disabled => false)
-
+                     :partial => "spree/admin/products/additional_product_tabs")

--- a/app/overrides/add_pricing_to_cart_form.rb
+++ b/app/overrides/add_pricing_to_cart_form.rb
@@ -1,5 +1,4 @@
 Deface::Override.new(:virtual_path => "spree/products/_cart_form",
                          :name => "converted_product_price_331970321",
                          :insert_after => "[data-hook='product_price'], #product_price[data-hook]",
-                         :partial => "spree/products/pricing",
-                         :disabled => false)
+                         :partial => "spree/products/pricing")

--- a/app/overrides/flexi_variants_admin_tabs.rb
+++ b/app/overrides/flexi_variants_admin_tabs.rb
@@ -1,5 +1,4 @@
 Deface::Override.new(:virtual_path => "spree/layouts/admin",
                      :name => "flexi_variants_admin_tabs",
                      :insert_bottom => "[data-hook='admin_tabs'], #admin_tabs[data-hook]",
-                     :text => "<%= tab(:product_customization_types, :url => spree.admin_product_customization_types_path) %>",
-                     :disabled => false)
+                     :text => "<%= tab(:product_customization_types, :url => spree.admin_product_customization_types_path) %>")

--- a/app/overrides/replace_admin_order_form_line_item_row.rb
+++ b/app/overrides/replace_admin_order_form_line_item_row.rb
@@ -1,5 +1,4 @@
 Deface::Override.new(:virtual_path => "spree/admin/orders/_line_item",
                          :name => "converted_admin_order_form_line_item_row_459848395",
                          :replace => "[data-hook='admin_order_form_line_item_row'], #admin_order_form_line_item_row[data-hook]",
-                         :partial => "spree/admin/orders/admin_order_form_line_item_row",
-                         :disabled => false)
+                         :partial => "spree/admin/orders/admin_order_form_line_item_row")


### PR DESCRIPTION
Hi

I removed the :disabled => false options in your overrides .rb files.
This option makes it impossible to disable your overrides in the main app.
I think this is caused by a (minor) bug in deface, I already opened an issue.

https://github.com/railsdog/deface/issues/26

Thanks

Matthias
