### PR TITLE
moved admin/order/flexi_configuration.js from manifest to assets pipeline

### DIFF
--- a/lib/generators/spree_flexi_variants/install/install_generator.rb
+++ b/lib/generators/spree_flexi_variants/install/install_generator.rb
@@ -3,7 +3,6 @@ module SpreeFlexiVariants
     class InstallGenerator < Rails::Generators::Base
 
       def add_javascripts
-        append_file "app/assets/javascripts/admin/all.js", "//= require admin/orders/flexi_configuration\n"
         append_file "app/assets/javascripts/store/all.js", "//= require store/spree_flexi_variants\n"
       end
 

--- a/lib/spree_flexi_variants/engine.rb
+++ b/lib/spree_flexi_variants/engine.rb
@@ -26,7 +26,7 @@ module SpreeFlexiVariants
     end
     # store/flexi-variants should be removed after renaming the files
     initializer "spree.flexi_variants.assets.precompile" do |app|
-        app.config.assets.precompile += ['store/spree_flexi_variants_exclusions.js','store/flexi-variants.*','store/spree-flexi-variants.*']
+        app.config.assets.precompile += ['store/spree_flexi_variants_exclusions.js','admin/orders/flexi_configuration.js','store/spree-flexi-variants.*']
     end
     # Had a good reason for this rescue below, and wish I'd commented it better when I wrote it
     # TODO - figure this out and de-ugly


### PR DESCRIPTION
related to issue (https://github.com/jsqu99/spree_flexi_variants/issues/27) this is the first step

I moved the js file to the assets pipeline so its not included in my app manifest all.js. this was wrong cause its included dynamical in:
https://github.com/jsqu99/spree_flexi_variants/blob/master/app/views/spree/admin/orders/_add_product.html.erb
