### PR TITLE
Move inline style from #ad_hoc_options in _ad_hoc_option_types

### DIFF
--- a/app/assets/stylesheets/store/spree-flexi-variants.css
+++ b/app/assets/stylesheets/store/spree-flexi-variants.css
@@ -62,6 +62,7 @@ we've got two versions line items: line_items & line-items
 
 #ad_hoc_options {
   margin-top: 20px;
+  overflow: auto;
 }
 table#cart-detail dl {margin-left: 10px;}
 table#cart-detail dt {font-weight: normal;}

--- a/app/views/spree/products/_ad_hoc_option_types.html.erb
+++ b/app/views/spree/products/_ad_hoc_option_types.html.erb
@@ -1,7 +1,7 @@
 <% if @product.ad_hoc_option_types && !@product.ad_hoc_option_types.empty? %>
 <% lookup=ActionView::LookupContext.new(ActionController::Base.view_paths, {:formats => [:html]}) %>
 
-<div id="ad_hoc_options" style="overflow: auto;">
+<div id="ad_hoc_options">
   <%= "<h4 id='not_all_available'>#{t(:not_all_combinations_available)}</h4>".html_safe if !@product.ad_hoc_variant_exclusions.empty? %>
 
   <h3><%= t(:select_variant_options) %></h3>


### PR DESCRIPTION
Sometimes I've wanted to play with the CSS for the Options block on a product page, but one piece of it is specified as an inline style in the view: overflow: auto.  I've added it to your stylesheet and pulled it from the view in this commit.  See what you think.
