### PR TITLE
Customization div shows up when the product has none configured

### DIFF
--- a/app/views/spree/products/_customizations.html.erb
+++ b/app/views/spree/products/_customizations.html.erb
@@ -1,4 +1,4 @@
-<% if @product.product_customization_types %>
+<% if @product.product_customization_types && !@product.product_customization_types.empty? %>
 
   <div id="product-customizations">
 


### PR DESCRIPTION
I looked at the code for the ad-hoc options partial and realized that the customization partial wasn't testing to see if the product customizations attribute was empty like ad-hoc options does.  That would explain why it shows up.

Here's a fix to make it match ad-hoc options' behavior.

Ted
