### PR TITLE
Require carrierwave so you dont have to explicitly add to Gemfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ Please see the Versionfile for working spree 1.0, 0.70 and  spree 0.60 versions
 Installation
 ------------
     # see the notes in Versionfile if you are using an older version of spree
-    gem 'rmagick'
-    gem 'carrierwave'
     gem 'spree_flexi_variants', :git=>'git@github.com:jsqu99/spree_flexi_variants.git'
 
     bundle install

--- a/lib/spree_flexi_variants.rb
+++ b/lib/spree_flexi_variants.rb
@@ -1,2 +1,3 @@
 require 'spree_core'
+require 'carrierwave'
 require 'spree_flexi_variants/engine'


### PR DESCRIPTION
This will make it so just adding the extension to your Gemfile is enough.
