### PR TITLE
Fix #49.  Retain Ad Hoc Options during Order Merge

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -37,6 +37,13 @@ module Spree
       end
     end
 
+    def merge!(order)
+      order.line_items.each do |line_item|
+        self.add_variant(line_item.variant, line_item.quantity, line_item.ad_hoc_option_value_ids, line_item.product_customizations)
+      end
+      order.destroy
+    end
+
     private
 
     # produces a list of [customizable_product_option.id,value] pairs for subsequent comparison


### PR DESCRIPTION
Previously ad hoc option types would be unintentionally discarded
from one of the variants during an order merge.

This would happen when a user had a cart when logged in, and a cart
non-logged in cart.  If the user then logs in, the carts are merged
in to a single logged in cart.

The merging process would ignore the ad hoc options and product
customizations added, creating a product with no ad hoc options even
if the product is required to have them.
