### PR TITLE
Spree 1 1 stable

### DIFF
--- a/app/controllers/spree/admin/product_customization_types_controller.rb
+++ b/app/controllers/spree/admin/product_customization_types_controller.rb
@@ -15,7 +15,8 @@ module Spree
       if @product_customization_type.customizable_product_options.empty?
         if !@product_customization_type.calculator.nil?
 
-          @product_customization_type.customizable_product_options.concat @product_customization_type.calculator.create_options
+          opts = @product_customization_type.calculator.create_options
+          @product_customization_type.customizable_product_options.concat opts if opts
 
           # for each mandatory input type
           #        @product_customization_type.calculator.required_fields.each_pair do |key, val|

--- a/app/models/spree/ad_hoc_option_type.rb
+++ b/app/models/spree/ad_hoc_option_type.rb
@@ -16,6 +16,10 @@ module Spree
       !(price_modifier_type.nil? || price_modifier_type.downcase=~/none/)
     end
 
+    def name
+      option_type.name
+    end
+
     def presentation
       option_type.presentation
     end

--- a/app/models/spree/customizable_product_option.rb
+++ b/app/models/spree/customizable_product_option.rb
@@ -2,6 +2,6 @@ module Spree
   class CustomizableProductOption < ActiveRecord::Base
     belongs_to :product_customization_type
     delegate :calculator, :to => :product_customization_type
-    attr_accessible :name, :presentation, :description
+    attr_accessible :name, :presentation, :description, :product_customization_type_id
   end
 end

--- a/app/views/spree/admin/orders/_admin_order_form_line_item_row.html.erb
+++ b/app/views/spree/admin/orders/_admin_order_form_line_item_row.html.erb
@@ -8,9 +8,6 @@
 <td valign="top" class="qty"><%=f.text_field :quantity, :style => "width:30px;", :class => "qty" %></td>
 <td valign="top" class="total"><%= number_to_currency (f.object.price * f.object.quantity)%></td>
   <td data-hook="admin_order_form_line_item_actions">
-    <%= link_to_delete f.object, {:url => admin_order_line_item_url(@order.number, f.object),
-                                  :dataType => "html" ,
-                                  :success => "function(r){ jQuery('#order-form-wrapper').html(r);}"},
-                                  :title => "admin_delete_#{dom_id(@order)}" %>
+    <%= link_to_delete f.object, {:url => admin_order_line_item_url(@order.number, f.object)} %>
   </td>
 </tr>

--- a/app/views/spree/admin/product_customization_types/_customizable_product_option_fields.html.erb
+++ b/app/views/spree/admin/product_customization_types/_customizable_product_option_fields.html.erb
@@ -2,4 +2,5 @@
   <td><%= f.text_field :name, :readonly => true, :disabled => true %></td>
   <td><%= f.text_field :presentation %></td>
   <td><%= f.text_area :description, {:style=>'height: auto;', :rows => 3, :cols => 25} %></td>
+  <td class="actions"><%= link_to_remove_fields t("remove"), f %></td>
 </tr>

--- a/app/views/spree/admin/product_customization_types/edit.html.erb
+++ b/app/views/spree/admin/product_customization_types/edit.html.erb
@@ -21,6 +21,7 @@
         <th><%= t("name") %></th>
         <th><%= t("presentation") %></th>
         <th><%= t("description") %></th>
+        <th></th>
       </tr>
     </thead>
     <tbody id="customizable_product_options">
@@ -32,6 +33,7 @@
       <% end %>
     </tbody>
   </table>
+  <%# link_to_add_fields t("add_customizable_product_option"), "tbody#customizable_product_options", f, :customizable_product_options %>
 
 <!-- b/c of r_c removal -->
 <p class="form-buttons">

--- a/app/views/spree/products/_content_for_head.html.erb
+++ b/app/views/spree/products/_content_for_head.html.erb
@@ -10,7 +10,7 @@
 	  <% ov=excl.excluded_ad_hoc_option_values.detect { |eov| eov.ad_hoc_option_value.option_type == ot } %>
 
 	  <% ov_str = ov.nil? ? "*" : ov.ad_hoc_option_value.id.to_s %>
-	  <%= "'ad_hoc_option_values_#{ot.id}':'#{ov_str}'" %>
+	  <%= raw "'ad_hoc_option_values_#{ot.id}':'#{ov_str}'" %>
 	  <% unless ot == @product.ad_hoc_option_types.last %>
 	    ,
 	  <% end %>


### PR DESCRIPTION
This fixes the 'wrong number of arguments (3 for 2)' I got in admin edit/orders after Spree 1-1-stable update from 1.1.0 to 1.1.3 (maybe 1.1.2 too)

It is basically backporting 'app/views/spree/admin/orders/_admin_order_form_line_item_row.html.erb' partial from the Master branch back into the 1-1-stable branch.
