### PR TITLE
Spree 1.3 - nested resources on admin screens

### DIFF
--- a/app/helpers/spree/admin/base_helper_decorator.rb
+++ b/app/helpers/spree/admin/base_helper_decorator.rb
@@ -1,0 +1,15 @@
+module Spree
+  module Admin
+    BaseHelper.module_eval do
+      #renders hidden field and link to remove record using nested_attributes
+      def link_to_remove_nested_fields(name, f, options = {})
+        name = '' if options[:no_text]
+        options[:class] = '' unless options[:class]
+        options[:class] += 'no-text with-tip' if options[:no_text]
+        options[:nest] = '' unless options[:nest]
+        url = f.object.persisted? ? [:admin, options[:nest], f.object] : '#'
+        link_to_with_icon('icon-trash', name, url, :class => "remove_fields #{options[:class]}", :data => {:action => 'remove'}, :title => t(:remove)) + f.hidden_field(:_destroy)
+      end
+    end
+  end
+end

--- a/app/views/spree/admin/ad_hoc_option_types/_option_value_fields.html.erb
+++ b/app/views/spree/admin/ad_hoc_option_types/_option_value_fields.html.erb
@@ -3,5 +3,5 @@
   <td class='presentation'><span>  <%= f.object.option_value.presentation %> </span></td>
   <td class='price_modifier'><%= f.text_field :price_modifier %></td>
   <td><%= f.check_box :selected %></td>
-  <td class="actions"><%= link_to_remove_fields t("remove"), f %></td>
+  <td class="actions"><%= link_to_remove_nested_fields t("remove"), f, :no_text => true, :nest => "ad_hoc_option_type" %></td>
 </tr>

--- a/app/views/spree/admin/product_customization_types/_customizable_product_option_fields.html.erb
+++ b/app/views/spree/admin/product_customization_types/_customizable_product_option_fields.html.erb
@@ -2,5 +2,5 @@
   <td><%= f.text_field :name, :readonly => true, :disabled => true %></td>
   <td><%= f.text_field :presentation %></td>
   <td><%= f.text_area :description, {:style=>'height: auto;', :rows => 3, :cols => 25} %></td>
-  <td class="actions"><%= link_to_remove_fields t("remove"), f %></td>
+  <td class="actions"><%= link_to_remove_nested_fields t("remove"), f, :no_text => true, :nest => "product_customization_type" %></td>
 </tr>


### PR DESCRIPTION
Please can you review my attempt to fix the issue with editing nested resources in admin screens seen when using this extension in combination with Spree v1.3 (#61, #60 & #52).

I am quite new to both Rails and Spree (and OS contribution), so apologies in advance if I've missed anything here.

Basically, the issue seems to be incorrect routes urls being created by the link_to_remove_fields method in core Spree 1.3 when used with nested resources e.g. 

```
resources :product_customization_types do
  resources :customizable_product_options do
```

and

```
resources :ad_hoc_option_types do
  resources :ad_hoc_option_values do
```

The extension's routes definition creates fully qualified paths combining both inner and outer resource:

```
admin_product_customization_type_customizable_product_option
admin_ad_hoc_option_type_ad_hoc_option_value 
```

however the link_to_remove_fields method in core Spree 1.3 doesn't know anything about the outer resource. There may well be a more graceful way of solving this issue, but as I'm new to Ruby and Rails I created a new helper (link_to_remove_nested_fields) method to cope with the nesting and modified the places that this extension calls link_to_remove_fields.

I hope this is useful.
