### PR TITLE
Updated admin styles for ad hoc options.

### DIFF
--- a/app/views/spree/admin/ad_hoc_option_types/_form.html.erb
+++ b/app/views/spree/admin/ad_hoc_option_types/_form.html.erb
@@ -1,6 +1,6 @@
 <% # first two are read only (come from opiton_type.rb) %>
-<h3><%= t("name") %>:<%= f.object.option_type.name%></h3>
-<h3><%= t("presentation") %>:<%= f.object.option_type.presentation%></h3>
+<h3><%= t("name") %>: <%= f.object.option_type.name%></h3>
+<h3><%= t("presentation") %>: <%= f.object.option_type.presentation%></h3>
 <%= f.field_container :is_required do %>
   <%= f.label :position, t("position_within_product") %><br />
   <%= f.number_field :position %>

--- a/app/views/spree/admin/ad_hoc_option_types/_selected.html.erb
+++ b/app/views/spree/admin/ad_hoc_option_types/_selected.html.erb
@@ -1,37 +1,42 @@
-<h3>Add Option Types that can be used to dynamically create ad hoc variants</h3>
+<h3>Add Option Types</h3>
+<p>These can be used to dynamically create ad hoc variants</p>
 <table class="index">
-  <tr>
-    <th><%= t("name") %></th>
-    <th><%= t("presentation") %></th>
-    <th><%= t("required") %></th>
-    <th>&nbsp;</th>
-  </tr>
-  <% @option_types.each do |ahot| %>
+  <thead>
+    <tr>
+      <th><%= t("name") %></th>
+      <th><%= t("presentation") %></th>
+      <th><%= t("required") %></th>
+      <th class='actions'></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @option_types.each do |ahot| %>
 
-    <% if ahot.option_type.id.to_s == @last_selected_option_type_id %>  
-      <% # do we need to do the 'first time' forced-edit/save of new option values? %>
+      <% if ahot.option_type.id.to_s == @last_selected_option_type_id %>
+        <% # do we need to do the 'first time' forced-edit/save of new option values? %>
 
-      <%= render :partial => "form", :locals => { :f => f } %>
-      <%= render :partial => "selected_edit", :locals => { :ahot => ahot } %>
-    <% else %>
-      <tr>
-        <td><%= ahot.option_type.name %></td>
-        <td><%= ahot.option_type.presentation %></td>
-        <td><%= ahot.is_required %></td>
-        <td class="actions">
-          <%= link_to_with_icon 'edit',  t("edit"), edit_admin_ad_hoc_option_type_url(ahot) %>
-          <%= link_to_with_icon 'delete',  t("remove"), remove_admin_ad_hoc_option_type_url(ahot) %>
-        </td>
-      </tr>
+        <%= render :partial => "form", :locals => { :f => f } %>
+        <%= render :partial => "selected_edit", :locals => { :ahot => ahot } %>
+      <% else %>
+        <tr>
+          <td><%= ahot.option_type.name %></td>
+          <td><%= ahot.option_type.presentation %></td>
+          <td><%= ahot.is_required %></td>
+          <td class="actions">
+            <%= link_to_edit ahot, no_text: true %>
+            <%= link_to_delete ahot, no_text: true %>
+          </td>
+        </tr>
+      <% end %>
     <% end %>
-  <% end %>
+  </tbody>
   <% if @option_types.empty? %>
   <tr><td colspan="3"><%= t(:none) %></td></tr>
   <% end %>
 </table>
 
 <div id="option-types"></div>
-<span id="new_opt_link">     
+<span id="new_opt_link">
   <!-- THIS pulls up the 'available' list below -->
-  <%= link_to icon('add') + ' ' + t("add_option_type"), available_ad_hoc_admin_product_option_types_url(@product), :remote => :true, :class => 'iconlink' %>
+  <%= button_link_to t("add_option_type"), available_ad_hoc_admin_product_option_types_url(@product), :remote => :true, :class => 'iconlink', :icon => 'icon-plus' %>
 </span>

--- a/app/views/spree/admin/ad_hoc_option_types/edit.html.erb
+++ b/app/views/spree/admin/ad_hoc_option_types/edit.html.erb
@@ -13,15 +13,18 @@
         <th><%= t("display") %></th>
         <th><%= t("price_modifier") %></th>
         <th><%= t("selected_by_default") %></th>
-        <th></th>
+        <th class='actions'></th>
       </tr>
     </thead>
     <tbody id="option_values">
-      <tr id="none">
-        <td colspan="4"><%= @ad_hoc_option_type.option_values.empty? ? t("none") : "" %></td>
-      </tr>
-      <%= f.fields_for :ad_hoc_option_values do |option_value_form| %>
-        <%= render "option_value_fields", :f => option_value_form %>
+      <% if @ad_hoc_option_type.option_values.empty? %>
+        <tr>
+          <td colspan="4"><%= t("none") %></td>
+        </tr>
+      <% else %>
+        <%= f.fields_for :ad_hoc_option_values do |option_value_form| %>
+          <%= render "option_value_fields", :f => option_value_form %>
+        <% end %>
       <% end %>
     </tbody>
   </table>
@@ -37,9 +40,10 @@
     </div>
   <% end %>
 
-  <p class="form-buttons">
-    <%= button t("update") %>
-    <%= t("or") %> <%= link_to t("cancel"), selected_admin_product_ad_hoc_option_types_url(@ad_hoc_option_type.product) %>
-  </p>
+  <div class="form-buttons filter-actions actions">
+    <%= button t("update"), 'icon-refresh' %>
+    <span class='or'><%= t("or") %></span>
+    <%= button_link_to t("cancel"), selected_admin_product_ad_hoc_option_types_url(@ad_hoc_option_type.product), :icon => 'icon-remove' %>
+  </div>
 </fieldset>
 <% end %>

--- a/app/views/spree/admin/option_types/_available_ad_hoc.html.erb
+++ b/app/views/spree/admin/option_types/_available_ad_hoc.html.erb
@@ -1,27 +1,31 @@
 <h4><%= t("add_option_types") %></h4>
 <table class="index">
-  <tr>
-    <th><%= t("name") %></th>
-    <th><%= t("presentation") %></th>
-    <th></th>
-  </tr>
-  <% @available_option_types.each do |ot| %>
-  <tr>
-    <td><%=ot.name %></td>
-    <td><%=ot.presentation %></td>
-    <td class="actions"><%= link_to icon('add') + ' ' + t("select"),
-                            url_for(:controller => "admin/option_types",
-                                    :id => ot,
-                                    :product_id => @product.permalink,
-                                    :action => "select_ad_hoc",
-                                    :option_type_id =>  ot),
-          :class => 'iconlink' %>
-    </td>
-  </tr>
-  <% end %>
-  <% if @available_option_types.empty? %>
-  <tr>
-    <td colspan="3"><%= t('none_available') %></td>
-  </tr>
-  <% end %>
+  <thead>
+    <tr>
+      <th><%= t("name") %></th>
+      <th><%= t("presentation") %></th>
+      <th class='actions'></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @available_option_types.each do |ot| %>
+      <tr>
+        <td><%=ot.name %></td>
+        <td><%=ot.presentation %></td>
+        <td class="actions"><%= link_to_with_icon 'icon-plus', t("select"),
+          url_for(:controller => "admin/option_types",
+                  :id => ot,
+                  :product_id => @product.permalink,
+                  :action => "select_ad_hoc",
+                  :option_type_id =>  ot),
+                  :class => 'iconlink' %>
+        </td>
+      </tr>
+    <% end %>
+    <% if @available_option_types.empty? %>
+      <tr>
+        <td colspan="3"><%= t('none_available') %></td>
+      </tr>
+    <% end %>
+  </tbody>
 </table>


### PR DESCRIPTION
This change updates the look of the flexi variants area a little.  It matches the 1.3 style a little better.  A quick sample:

Before:
![flexi-variants-style-before](https://f.cloud.github.com/assets/764390/498405/cbbf85da-bc14-11e2-8ffa-8ecbf7eee559.png)

After:
![flexi-variants-after](https://f.cloud.github.com/assets/764390/498406/d06fedcc-bc14-11e2-824a-cf5a93aee359.png)
