### PR TITLE
Add cost price modifier to option value.

### DIFF
--- a/app/models/spree/ad_hoc_option_value.rb
+++ b/app/models/spree/ad_hoc_option_value.rb
@@ -6,7 +6,7 @@ module Spree
     has_many :excluded_ad_hoc_option_values, :dependent => :destroy
 
     # currently no controller for normal users present
-    attr_accessible :price_modifier, :ad_hoc_option_type_id, :option_value_id, :selected
+    attr_accessible :price_modifier, :ad_hoc_option_type_id, :option_value_id, :selected, :cost_price_modifier
 
     # this opens up a can of worms..deleting option values and having historical data still intact...ugh...what to do?...add 'deleted_at' somewhere along the chain?
     # has_many :ad_hoc_option_values_line_items, :dependent => :destroy
@@ -19,5 +19,8 @@ module Spree
     delegate :name, :to => :option_value
     delegate :presentation, :to => :option_value
 
+    def cost_price
+      cost_price_modifier || price_modifier || 0
+    end
   end
 end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -32,5 +32,13 @@ module Spree
 
       str.join('\n')
     end
+
+    def cost_price
+      variant.cost_price + ad_hoc_option_values.map(&:cost_price).inject(0, :+)
+    end
+
+    def cost_money
+      Spree::Money.new(cost_price, :currency => currency)
+    end
   end
 end

--- a/app/views/spree/admin/ad_hoc_option_types/_option_value_fields.html.erb
+++ b/app/views/spree/admin/ad_hoc_option_types/_option_value_fields.html.erb
@@ -2,6 +2,7 @@
   <td class='name'><span class="handle"></span><span> <%= f.object.option_value.name %> </span></td>
   <td class='presentation'><span>  <%= f.object.option_value.presentation %> </span></td>
   <td class='price_modifier'><%= f.text_field :price_modifier %></td>
+  <td class='cost_price_modifier'><%= f.text_field :cost_price_modifier %></td>
   <td><%= f.check_box :selected %></td>
   <td class="actions"><%= link_to_remove_fields t("remove"), f %></td>
 </tr>

--- a/app/views/spree/admin/ad_hoc_option_types/edit.html.erb
+++ b/app/views/spree/admin/ad_hoc_option_types/edit.html.erb
@@ -12,6 +12,7 @@
         <th><%= t("name") %></th>
         <th><%= t("display") %></th>
         <th><%= t("price_modifier") %></th>
+        <th><%= t("cost_price_modifier") %></th>
         <th><%= t("selected_by_default") %></th>
         <th class='actions'></th>
       </tr>

--- a/db/migrate/20130513221643_add_cost_price_modifier_to_spree_ad_hoc_option_values.rb
+++ b/db/migrate/20130513221643_add_cost_price_modifier_to_spree_ad_hoc_option_values.rb
@@ -1,0 +1,5 @@
+class AddCostPriceModifierToSpreeAdHocOptionValues < ActiveRecord::Migration
+  def change
+    add_column :spree_ad_hoc_option_values, :cost_price_modifier, :decimarl, :precision => 8, :scale => 2
+  end
+end


### PR DESCRIPTION
This allows users to write reports which are based upon the increased
price of an option type vs. the increased cost to the store owner.

![option-value-cost](https://f.cloud.github.com/assets/764390/502699/6dc4cc30-bcb7-11e2-9b68-2db1e865ced6.png)

The functionality isn't used anywhere else, but we have a couple custom reports based on cost price that we want to use in conjunction with flexi-variants, and I figured others may find this useful.
