### PR TITLE
Fix for disappearing options on small screens.

### DIFF
--- a/app/assets/stylesheets/store/spree-flexi-variants.css
+++ b/app/assets/stylesheets/store/spree-flexi-variants.css
@@ -64,6 +64,12 @@ we've got two versions line items: line_items & line-items
   margin-top: 20px;
   overflow: auto;
 }
+
+@media (max-width: 767px) {
+  #ad_hoc_options {
+    overflow: inherit;
+  }
+}
 table#cart-detail dl {margin-left: 10px;}
 table#cart-detail dt {font-weight: normal;}
 table#cart-detail dl p {margin:0;}


### PR DESCRIPTION
On screen widths under 768px the options end up being hidden due to the overflow. This breaks the product page because users are unable to add items to a cart without selecting the variants.
