### PR TITLE
Add BaseHelper to OrderHamiler

### DIFF
--- a/app/mailers/spree/order_mailer_decorator.rb
+++ b/app/mailers/spree/order_mailer_decorator.rb
@@ -1,0 +1,3 @@
+Spree::OrderMailer.class_eval do
+  helper Spree::BaseHelper
+end

--- a/app/mailers/spree/shipment_mailer_decorator.rb
+++ b/app/mailers/spree/shipment_mailer_decorator.rb
@@ -1,0 +1,3 @@
+Spree::ShipmentMailer.class_eval do
+  helper Spree::BaseHelper
+end


### PR DESCRIPTION
This fixes an undefined method `variant_options` exception.

```
NoMethodError - undefined method `variant_options' for #<#<Class:0x00000008bb8778>:0x00000008bc1710>:
  /home/gmacdougall/.rvm/gems/ruby-1.9.3-p392/bundler/gems/spree_flexi_variants-78c14fbfa3c1/app/views/spree/order_mailer/confirm_email.text.erb:9:in `block in _702fd526a5e957338f1b9afa0347dc20'
```

This change should be merged in to master as well.
