### PR TITLE
Converts calls to `.live()` to `.on()` and `.die() to `.off()`

### DIFF
--- a/app/assets/javascripts/admin/orders/edit.js
+++ b/app/assets/javascripts/admin/orders/edit.js
@@ -1,8 +1,8 @@
 // overrides spree core's version to include our variant configurations
 $(document).ready(function(){
 
-  $("#add_line_item_to_order").die("click"); // remove spree's version
-  $("#add_line_item_to_order").live("click", function(){
+  $(document).off("click", "#add_line_item_to_order"); // remove spree's version
+  $(document).on("click", "#add_line_item_to_order", function(){
     if($('#add_variant_id').val() == ''){ return false; }
     update_target = $(this).attr("data-update");
     $.ajax({ dataType: 'script', url: this.href, type: "POST",

--- a/app/views/spree/products/customizations/calculator_type/_amount_times_constant.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_amount_times_constant.html.erb
@@ -9,7 +9,7 @@
 
   <%= content_for :head do %>
     <%= javascript_tag do %>
-      $('#<%= cust_dom_id %>').live('keyup', function(e) {
+      $(document).on('keyup', '#<%= cust_dom_id %>', function(e) {
 
         var tf = $(this);
 

--- a/app/views/spree/products/customizations/calculator_type/_customization_image.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_customization_image.html.erb
@@ -9,7 +9,7 @@
 
   <%= content_for :head do %>
     <%= javascript_tag do %>
-      $('#<%= cust_dom_id %>').live('change', function(e) {
+      $(document).on('change', '#<%= cust_dom_id %>', function(e) {
 
         // update the hidden price field for this file input
         $(this).siblings(".customization_price").val(calculate_customization_image_price(this));

--- a/app/views/spree/products/customizations/calculator_type/_engraving.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_engraving.html.erb
@@ -9,7 +9,7 @@
 
   <%= content_for :head do %>
     <%= javascript_tag do %>
-      $('#<%= cust_dom_id %>').live('keyup', function(e) {
+      $(document).on('keyup', '#<%= cust_dom_id %>', function(e) {
 
         var tf = $(this);
 

--- a/app/views/spree/products/customizations/calculator_type/_product_area.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_product_area.html.erb
@@ -10,7 +10,7 @@
 
   <%= content_for :head do %>
     <%= javascript_tag do %>
-      $('#<%= width_dom_id %> , #<%= height_dom_id %>').live('keyup', function(e) {
+      $(document).on('keyup', '#<%= width_dom_id %> , #<%= height_dom_id %>', function(e) {
 
         var tf = $(this);
 


### PR DESCRIPTION
`.live()` and `.die()` were deprecated in jQuery 1.7, and removed in jQuery 1.9.

See: http://api.jquery.com/category/deprecated/deprecated-1.7/ and http://api.jquery.com/category/removed/
