### PR TITLE
Only redirect for html requests

### DIFF
--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -26,7 +26,7 @@ module Spree
       fire_event('spree.cart.add')
       fire_event('spree.order.contents_changed')
 
-      redirect_to cart_path
+      redirect_to cart_path if request.format.html?
     end
 
   end


### PR DESCRIPTION
This is needed for compatibility with [spree_minicart](https://github.com/sbounmy/spree_minicart), but might be a useful change in general.
