### PR TITLE
Order decorator fixes

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,7 +1,7 @@
 module Spree
   Order.class_eval do
     def add_variant(variant, quantity = 1, ad_hoc_option_value_ids=[], product_customizations=[])
-      current_item = contains?(variant, ad_hoc_option_value_ids, product_customizations)
+      current_item = find_line_item_by_variant(variant, ad_hoc_option_value_ids, product_customizations)
       if current_item
         current_item.quantity += quantity
         current_item.save


### PR DESCRIPTION
'current_item' in order decorator is now an instance of `variant` instead of truthy/falsy values.

Issue: https://github.com/jsqu99/spree_flexi_variants/issues/99.
